### PR TITLE
first attempt at vectorizing window.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX 		= g++ 
-FLAGS 		= -O3 -std=c++17
+FLAGS 		= -O3 -std=c++17 -march=skylake-avx512
 TESTFOLDER  = test/
 UTILFOLDER  = util/
 

--- a/lib/Window.cpp
+++ b/lib/Window.cpp
@@ -1,9 +1,11 @@
 #pragma once
 #include <deque>
 #include <algorithm>
+#include <immintrin.h>
 
 //MAX WINDOW SIZE IS 127
 #define WINDOW_SIZE 127
+#define VECTOR_WIDTH 8
 
 class Window
 {
@@ -49,11 +51,20 @@ public:
 
     inline uint64_t getCandidate(uint64_t val)
     {
-        
+        /*
         for (int i = 0; i < WINDOW_SIZE; i++)
         {
             tmp[i] = val ^ buffer[i];
-        }
+        }*/
+
+        __m512i vals = _mm512_set_epi64(val, val, val, val, val, val, val, val); 
+        for(int i = 0; i< WINDOW_SIZE / VECTOR_WIDTH; i+= VECTOR_WIDTH)
+        {
+            
+            __m512i buf_values = _mm512_load_epi64(&buffer[i]); 
+            __m512i result = _mm512_xor_epi64(buf_values, vals); 
+            _mm512_store_epi64(&tmp[i], result); 
+        } 
 
         std::transform(tmp.begin(),
                        tmp.end(),
@@ -69,6 +80,7 @@ public:
                            }
                        });
 
+        // TODO: Finding the max into tmp can similarly be vectorized. 
         auto maxid = std::distance(tmp.begin(), std::max_element(tmp.begin(), tmp.end()));
         return buffer[maxid];
     }


### PR DESCRIPTION
I have not tested this yet ... 
Finding the distance at the bottom of the function should also be vectorizable.

The right way to do this, is to first test for AVX512, AVX2, etc. and use the vector width that is available on the machine. 
Not sure the right flags to use for gcc, but it should be able to auto-vectorize this loop. 
For ICC, one can try: icc -xCORE-AVX512 -qopt-zmm-usage=high